### PR TITLE
Fixed allocating memory for buffer in TransposeChannelsKernel

### DIFF
--- a/Forge/Forge/TransposeChannels.swift
+++ b/Forge/Forge/TransposeChannels.swift
@@ -47,7 +47,8 @@ public class TransposeChannelsKernel {
 
     self.device = device
 
-    buffer = device.makeBuffer(length: MemoryLayout<UInt16>.stride * featureChannels)
+    let slices = (featureChannels + 3) / 4
+    buffer = device.makeBuffer(length: MemoryLayout<UInt16>.stride * slices * 4)
     memcpy(buffer.contents(), permute, MemoryLayout<UInt16>.stride * featureChannels)
 
     // If there's more than one texture slice in the image, we have to use a

--- a/Forge/Forge/TransposeChannels.swift
+++ b/Forge/Forge/TransposeChannels.swift
@@ -47,8 +47,7 @@ public class TransposeChannelsKernel {
 
     self.device = device
 
-    let slices = (featureChannels + 3) / 4
-    buffer = device.makeBuffer(length: MemoryLayout<UInt16>.stride * slices)
+    buffer = device.makeBuffer(length: MemoryLayout<UInt16>.stride * featureChannels)
     memcpy(buffer.contents(), permute, MemoryLayout<UInt16>.stride * featureChannels)
 
     // If there's more than one texture slice in the image, we have to use a


### PR DESCRIPTION
Buffer that was allocated for permutation was too small.